### PR TITLE
feat: restoring twitter account links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ navigation: True # show the navbar links
 subscribers: False # you need to connect an external service for this to work,
 # if 'True' the submit button is disabled for now, but you can change that
 # by editing `_includes/subscribe-form.html`
-#twitter: DarrylAnderson_ # replace by your username
+twitter: DarrylAnderson_ # replace by your username
 #facebook: ghost # replace by your username
 
 # Disqus

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -7,5 +7,5 @@ darryl:
   bio: Darryl provides technology advisement, design, and development services to early and growth stage software companies.
   picture: content/images/2018/03/ProfilePhoto-round-1.png
   facebook: False
-  twitter: False
+  twitter: DarrylAnderson_
   cover: False

--- a/_includes/site-nav.html
+++ b/_includes/site-nav.html
@@ -21,6 +21,10 @@
             <i class="fab fa-github"></i> github
           </a>
           &nbsp;&nbsp;
+          <a href="https://twitter.com/DarrylAnderson_" target="_blank" rel="noopener">
+            <i class="fab fa-twitter"></i> twitter
+          </a>
+          &nbsp;&nbsp;
         </div>
         {% if site.subscribers %}
             <a class="subscribe-button" href="#subscribe">Subscribe</a>

--- a/about/index.md
+++ b/about/index.md
@@ -27,6 +27,7 @@ Learn more about me at the links below:
 
 <i class="fab fa-linkedin"></i> [LinkedIn](https://linkedin.com/in/darryl-anderson) 
 <i class="fab fa-github"></i> [GitHub](https://github.com/darrylanderson)
+<i class="fab fa-twitter"></i> [Twitter](https://twitter.com/DarrylAnderson_)
 <i class="fab fa-angellist"></i> [AngelList](https://angel.co/darryl-anderson)
 
 Email: <darryl@andersontech.consulting>


### PR DESCRIPTION
Restoring twitter account links, given that they now at least enforce some
measure of sanity around content that incites violence and promotes hate.